### PR TITLE
fixed links in Low-latency Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ We have collected links to good articles to read if you would like to know more 
  
 - [Achieving low latency video streaming:](https://medium.com/@eyevinntechnology/achieving-low-latency-video-streaming-b0b806dcc282) Overview and example of low-latency streaming
 
-- [Using LL-HLS with byte-range addressing to achieve interoperability in low latency streaming:](https://blogs.akamai.com/2020/11/using-ll-hls-with-byte-range-addressing-to-achieve-interoperability-in-low-latency-streaming.html) This article investigate the problems solved with range-based addressing, the requirements it brings to operate effectively, and the benefits we can gain by deploying it at scale
+- [Using LL-HLS with byte-range addressing to achieve interoperability in low latency streaming:](https://web.archive.org/web/20210202232150/https://blogs.akamai.com/2020/11/using-ll-hls-with-byte-range-addressing-to-achieve-interoperability-in-low-latency-streaming.html) This article investigate the problems solved with range-based addressing, the requirements it brings to operate effectively, and the benefits we can gain by deploying it at scale
  
 - [Low latency HLS:](https://medium.com/@periscopecode/introducing-lhls-media-streaming-eb6212948bef) How to achieve low-latency HLS streaming
 
-- [Ultra Low latency CMAF:](https://blogs.akamai.com/2018/10/best-practices-for-ultra-low-latency-streaming-using-chunked-encoded-and-chunk-transferred-cmaf.html) Best Practices for Ultra-Low Latency Streaming Using Chunked-Encoded and Chunk-Transferred CMAF
+- [Ultra Low latency CMAF:](https://web.archive.org/web/20210124092321/https://blogs.akamai.com/2018/10/best-practices-for-ultra-low-latency-streaming-using-chunked-encoded-and-chunk-transferred-cmaf.html) Best Practices for Ultra-Low Latency Streaming Using Chunked-Encoded and Chunk-Transferred CMAF
 
 - [Ultra Low Latency Video Streaming: The Current State:](https://www.linkedin.com/pulse/ultra-low-latency-video-streaming-current-state-patrick-debois/) A good summary of the technology around low-latency streaming
 


### PR DESCRIPTION
I found broken links in Akamai's blog.

Instead I changed there links to Internet Archive